### PR TITLE
Modified pathfinding code to be PID for x/y/theta instead of traj

### DIFF
--- a/2025-Robot-Code/src/main/java/frc/robot/RobotContainer.java
+++ b/2025-Robot-Code/src/main/java/frc/robot/RobotContainer.java
@@ -176,23 +176,24 @@ public class RobotContainer {
                                 .onFalse(elevator.setElevatorTarget(ElevatorConstants.kStowedHeight));
                 driverController.y().whileTrue(elevator.setElevatorTarget(ElevatorConstants.kL4Height))
                                 .onFalse(elevator.setElevatorTarget(ElevatorConstants.kStowedHeight));
-
+                
+                // TODO: these should only be enabled for testing/auto tuning.
                 // Run SysId routines when holding back/start and X/Y.
                 // Note that each routine should be run exactly once in a single log.
-                driverController.back().and(driverController.y())
-                                .whileTrue(drivetrain.sysIdDynamic(Direction.kForward));
-                driverController.back().and(driverController.x())
-                                .whileTrue(drivetrain.sysIdDynamic(Direction.kReverse));
-                driverController.start().and(driverController.y())
-                                .whileTrue(drivetrain.sysIdQuasistatic(Direction.kForward));
-                driverController.start().and(driverController.x())
-                                .whileTrue(drivetrain.sysIdQuasistatic(Direction.kReverse));
+                // driverController.back().and(driverController.y())
+                //                 .whileTrue(drivetrain.sysIdDynamic(Direction.kForward));
+                // driverController.back().and(driverController.x())
+                //                 .whileTrue(drivetrain.sysIdDynamic(Direction.kReverse));
+                // driverController.start().and(driverController.y())
+                //                 .whileTrue(drivetrain.sysIdQuasistatic(Direction.kForward));
+                // driverController.start().and(driverController.x())
+                //                 .whileTrue(drivetrain.sysIdQuasistatic(Direction.kReverse));
 
                 // reset the field-centric heading on start button press
                 driverController.start().onTrue(drivetrain.runOnce(() -> drivetrain.seedFieldCentric()));
 
-                driverController.leftBumper().onTrue(drivetrain.getScoringPath(false));
-                driverController.rightBumper().onTrue(drivetrain.getScoringPath(true));
+                driverController.leftBumper().onTrue(drivetrain.driveToReef(false));
+                driverController.rightBumper().onTrue(drivetrain.driveToReef(true));
 
                 drivetrain.registerTelemetry(logger::telemeterize);
         }


### PR DESCRIPTION
This PR modifies the robot code to use a PID loop on x/y/theta rather than using a trajectory to translate the robot when approaching the reef.