### PR TITLE
Use JoystickApproach Alignment

### DIFF
--- a/2025-Robot-Code/src/main/java/frc/robot/Constants.java
+++ b/2025-Robot-Code/src/main/java/frc/robot/Constants.java
@@ -6,22 +6,16 @@ package frc.robot;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
 import com.ctre.phoenix6.CANBus;
 import com.pathplanner.lib.path.PathConstraints;
 
-import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Rotation3d;
-import edu.wpi.first.math.geometry.Transform2d;
+
 import edu.wpi.first.math.geometry.Transform3d;
-import edu.wpi.first.math.geometry.Translation2d;
+
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.util.Units;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import frc.robot.util.AllianceFlipUtil;
+
 
 /**
  * The Constants class provides a convenient place for teams to hold robot-wide
@@ -36,97 +30,6 @@ import frc.robot.util.AllianceFlipUtil;
  * constants are needed, to reduce verbosity.
  */
 public final class Constants {
-  public static class FieldConstants {
-    public static final double kFieldLength = 17.5482504;
-    public static final double kFieldWidth = 8.0518;
-    public static final Translation2d kReefCenter = new Translation2d(4.48945, kFieldWidth/2);
-
-    public static Pose2d[] blueCenterFaces =
-      new Pose2d[6]; // Starting facing away from the driver station in clockwise order
-    public static Pose2d[] redCenterFaces = 
-      new Pose2d[6];
-
-    static {
-      // Initialize faces
-      blueCenterFaces[3] =
-          new Pose2d(
-              Units.inchesToMeters(144.003),
-              Units.inchesToMeters(158.500),
-              Rotation2d.fromDegrees(180));
-      blueCenterFaces[4] =
-          new Pose2d(
-              Units.inchesToMeters(160.373),
-              Units.inchesToMeters(186.857),
-              Rotation2d.fromDegrees(120));
-      blueCenterFaces[5] =
-          new Pose2d(
-              Units.inchesToMeters(193.116),
-              Units.inchesToMeters(186.858),
-              Rotation2d.fromDegrees(60));
-      blueCenterFaces[0] =
-          new Pose2d(
-              Units.inchesToMeters(209.489),
-              Units.inchesToMeters(158.502),
-              Rotation2d.fromDegrees(0));
-      blueCenterFaces[1] =
-          new Pose2d(
-              Units.inchesToMeters(193.118),
-              Units.inchesToMeters(130.145),
-              Rotation2d.fromDegrees(-60));
-      blueCenterFaces[2] =
-          new Pose2d(
-              Units.inchesToMeters(160.375),
-              Units.inchesToMeters(130.144),
-              Rotation2d.fromDegrees(-120));
-      
-      for (int i = 0; i < 6; i++) {
-        redCenterFaces[i] = AllianceFlipUtil.applyUnchecked(blueCenterFaces[i]);
-      }
-    }
-    public static Map<Integer, Map<Boolean, Pose2d>> kScoringPoses = new HashMap<Integer, Map<Boolean, Pose2d>>();
-
-    static{
-      Pose2d startingPoseRight = new Pose2d(3.098, 3.851, Rotation2d.fromDegrees(0));
-      Pose2d startingPoseLeft = new Pose2d(3.098, 4.201, Rotation2d.fromDegrees(0));
-      for(int i = 0; i < 6; i++){
-        
-        Pose2d currentPoseLeft = startingPoseLeft.rotateAround(kReefCenter, Rotation2d.fromDegrees(60 * i));
-        Pose2d currentPoseRight = startingPoseRight.rotateAround(kReefCenter, Rotation2d.fromDegrees(60 * i));
-
-        SmartDashboard.putString("Pose " + i + " Left", "X: " + currentPoseLeft.getX() + 
-          ", Y: " + currentPoseLeft.getY() + ", Heading: " +
-          currentPoseLeft.getRotation());
-          SmartDashboard.putString("Pose " + i + " Right", "X: " + currentPoseRight.getX() + 
-          ", Y: " + currentPoseRight.getY() + ", Heading: " +
-          currentPoseRight.getRotation());
-      
-      }
-      kScoringPoses.put(0, new HashMap<Boolean, Pose2d>());
-      kScoringPoses.get(0).put(false, new Pose2d(5.881, 3.851, Rotation2d.fromDegrees(180))); //AL
-      kScoringPoses.get(0).put(true, new Pose2d(5.881, 4.201, Rotation2d.fromDegrees(180))); //AR
-      kScoringPoses.put(1, new HashMap<Boolean, Pose2d>());
-      kScoringPoses.get(1).put(false, new Pose2d(5.034, 2.733, Rotation2d.fromDegrees(120))); //BL
-      kScoringPoses.get(1).put(true, new Pose2d(5.337, 2.908, Rotation2d.fromDegrees(120))); //BR
-      kScoringPoses.put(2, new HashMap<Boolean, Pose2d>());
-      kScoringPoses.get(2).put(false, new Pose2d(3.642, 2.908, Rotation2d.fromDegrees(60))); //CL
-      kScoringPoses.get(2).put(true, new Pose2d(3.945, 2.733, Rotation2d.fromDegrees(60))); //CR
-      kScoringPoses.put(3, new HashMap<Boolean, Pose2d>());
-      kScoringPoses.get(3).put(false, new Pose2d(3.098, 4.201, Rotation2d.fromDegrees(0))); //DL
-      kScoringPoses.get(3).put(true, new Pose2d(3.098, 3.851, Rotation2d.fromDegrees(0))); //DR
-      kScoringPoses.put(4, new HashMap<Boolean, Pose2d>());
-      kScoringPoses.get(4).put(false, new Pose2d(3.945, 5.318, Rotation2d.fromDegrees(300))); //EL
-      kScoringPoses.get(4).put(true, new Pose2d(3.642, 5.143, Rotation2d.fromDegrees(300))); //ER
-      kScoringPoses.put(5, new HashMap<Boolean, Pose2d>());
-      kScoringPoses.get(5).put(false, new Pose2d(5.337, 5.143, Rotation2d.fromDegrees(240))); //FL
-      kScoringPoses.get(5).put(true, new Pose2d(5.034, 5.318, Rotation2d.fromDegrees(240))); //FR
-    }
-    public static final Pose2d kCoral1PoseLeft = new Pose2d(1.65, 0.72, Rotation2d.fromDegrees(55));
-    public static final Pose2d kCoral1PoseRight = new Pose2d(1.11, 1.10, Rotation2d.fromDegrees(55));
-    public static final Pose2d kCoral2PoseRight = new Pose2d(1.65, 7.50, Rotation2d.fromDegrees(305));
-    public static final Pose2d kCoral2PoseLeft = new Pose2d(1.13, 7.04, Rotation2d.fromDegrees(305));
-    
-
-  }
 
   public static class OperatorConstants {
     public static final int kDriverControllerPort = 0;

--- a/2025-Robot-Code/src/main/java/frc/robot/FieldConstants.java
+++ b/2025-Robot-Code/src/main/java/frc/robot/FieldConstants.java
@@ -198,8 +198,7 @@ public class FieldConstants {
         public final double pitch;
     }
 
-    public static Pose2d getNearestReefFace(Pose2d currentPose)
-    {
+    public static Pose2d getNearestReefFace(Pose2d currentPose) {
         return currentPose.nearest(List.of(FieldConstants.Reef.centerFaces));
     }
 
@@ -208,16 +207,14 @@ public class FieldConstants {
         RIGHT
     }
 
-    public static Pose2d getNearestReefBranch(Pose2d currentPose, ReefSide side)
-    {
+    public static Pose2d getNearestReefBranch(Pose2d currentPose, ReefSide side) {
         return FieldConstants.Reef.branchPositions
             .get(List.of(FieldConstants.Reef.centerFaces).indexOf(getNearestReefFace(currentPose))
                 * 2 + (side == ReefSide.LEFT ? 1 : 0))
             .get(FieldConstants.ReefHeight.L1).toPose2d();
     }
 
-    public static Pose2d getNearestCoralStation(Pose2d currentPose)
-    {
+    public static Pose2d getNearestCoralStation(Pose2d currentPose) {
         if (currentPose.getTranslation().getX() > FieldConstants.fieldLength / 2) {
             if (currentPose.getTranslation().getY() > FieldConstants.fieldWidth / 2) {
                 return FieldConstants.CoralStation.rightCenterFace

--- a/2025-Robot-Code/src/main/java/frc/robot/FieldConstants.java
+++ b/2025-Robot-Code/src/main/java/frc/robot/FieldConstants.java
@@ -1,0 +1,237 @@
+// Copyright (c) 2025 FRC 6328
+// http://github.com/Mechanical-Advantage
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file at
+// the root directory of this project.
+
+package frc.robot;
+
+import edu.wpi.first.math.geometry.*;
+import edu.wpi.first.math.util.Units;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Contains various field dimensions and useful reference points. All units are in meters and poses
+ * have a blue alliance origin.
+ */
+public class FieldConstants {
+    public static final double fieldLength = Units.inchesToMeters(690.876);
+    public static final double fieldWidth = Units.inchesToMeters(317);
+    public static final Translation2d fieldCenter =
+        new Translation2d(fieldLength / 2, fieldWidth / 2);
+    public static final double startingLineX =
+        Units.inchesToMeters(299.438); // Measured from the inside of starting
+    // line
+
+    public static class Processor {
+        public static final Pose2d centerFace =
+            new Pose2d(Units.inchesToMeters(235.726), 0, Rotation2d.fromDegrees(90));
+    }
+
+    public static class Barge {
+        public static final Translation2d farCage =
+            new Translation2d(Units.inchesToMeters(345.428), Units.inchesToMeters(286.779));
+        public static final Translation2d middleCage =
+            new Translation2d(Units.inchesToMeters(345.428), Units.inchesToMeters(242.855));
+        public static final Translation2d closeCage =
+            new Translation2d(Units.inchesToMeters(345.428), Units.inchesToMeters(199.947));
+
+        // Measured from floor to bottom of cage
+        public static final double deepHeight = Units.inchesToMeters(3.125);
+        public static final double shallowHeight = Units.inchesToMeters(30.125);
+    }
+
+    public static class CoralStation {
+        public static final Pose2d leftCenterFace =
+            new Pose2d(
+                Units.inchesToMeters(33.526),
+                Units.inchesToMeters(291.176),
+                Rotation2d.fromDegrees(90 - 144.011));
+        public static final Pose2d rightCenterFace =
+            new Pose2d(
+                Units.inchesToMeters(33.526),
+                Units.inchesToMeters(25.824),
+                Rotation2d.fromDegrees(144.011 - 90));
+    }
+
+    public static class Reef {
+        public static final Translation2d centerOfReef =
+            new Translation2d(Units.inchesToMeters(176.746), Units.inchesToMeters(158.501));
+        public static final double faceToZoneLine =
+            Units.inchesToMeters(12); // Side of the reef to the inside of the
+        // reef zone line
+
+        public static final Pose2d[] centerFaces =
+            new Pose2d[12]; // Starting facing the driver station in clockwise order
+        public static final List<Map<ReefHeight, Pose3d>> branchPositions =
+            new ArrayList<>(); // Starting at the right branch facing the driver station in clockwise order
+
+        static {
+            // Initialize faces
+            centerFaces[0] =
+                new Pose2d(
+                    Units.inchesToMeters(144.003),
+                    Units.inchesToMeters(158.500),
+                    Rotation2d.fromDegrees(180));
+            centerFaces[1] =
+                new Pose2d(
+                    Units.inchesToMeters(160.373),
+                    Units.inchesToMeters(186.857),
+                    Rotation2d.fromDegrees(120));
+            centerFaces[2] =
+                new Pose2d(
+                    Units.inchesToMeters(193.116),
+                    Units.inchesToMeters(186.858),
+                    Rotation2d.fromDegrees(60));
+            centerFaces[3] =
+                new Pose2d(
+                    Units.inchesToMeters(209.489),
+                    Units.inchesToMeters(158.502),
+                    Rotation2d.fromDegrees(0));
+            centerFaces[4] =
+                new Pose2d(
+                    Units.inchesToMeters(193.118),
+                    Units.inchesToMeters(130.145),
+                    Rotation2d.fromDegrees(-60));
+            centerFaces[5] =
+                new Pose2d(
+                    Units.inchesToMeters(160.375),
+                    Units.inchesToMeters(130.144),
+                    Rotation2d.fromDegrees(-120));
+
+            centerFaces[6] = centerFaces[0].rotateAround(fieldCenter, Rotation2d.k180deg);
+            centerFaces[7] = centerFaces[1].rotateAround(fieldCenter, Rotation2d.k180deg);
+            centerFaces[8] = centerFaces[2].rotateAround(fieldCenter, Rotation2d.k180deg);
+            centerFaces[9] = centerFaces[3].rotateAround(fieldCenter, Rotation2d.k180deg);
+            centerFaces[10] = centerFaces[4].rotateAround(fieldCenter, Rotation2d.k180deg);
+            centerFaces[11] = centerFaces[5].rotateAround(fieldCenter, Rotation2d.k180deg);
+
+            // Initialize branch positions
+            for (int face = 0; face < centerFaces.length; face++) {
+                Map<ReefHeight, Pose3d> fillRight = new HashMap<>();
+                Map<ReefHeight, Pose3d> fillLeft = new HashMap<>();
+                for (var level : ReefHeight.values()) {
+                    Pose2d poseDirection = new Pose2d();
+                    if (face < 6) {
+                        poseDirection =
+                            new Pose2d(centerOfReef, centerFaces[face].getRotation());
+                    } else {
+                        poseDirection =
+                            new Pose2d(centerOfReef.rotateAround(fieldCenter, Rotation2d.k180deg),
+                                centerFaces[face].getRotation());
+                    }
+
+                    double adjustX = Units.inchesToMeters(30.738); // Depth of branch from reef face
+                    double adjustY = Units.inchesToMeters(6.469); // Offset from reef face
+                                                                  // centerline to branch
+
+                    fillRight.put(
+                        level,
+                        new Pose3d(
+                            new Translation3d(
+                                poseDirection
+                                    .transformBy(
+                                        new Transform2d(adjustX, adjustY, new Rotation2d()))
+                                    .getX(),
+                                poseDirection
+                                    .transformBy(
+                                        new Transform2d(adjustX, adjustY, new Rotation2d()))
+                                    .getY(),
+                                level.height),
+                            new Rotation3d(
+                                0,
+                                Units.degreesToRadians(level.pitch),
+                                poseDirection.getRotation().getRadians())));
+                    fillLeft.put(
+                        level,
+                        new Pose3d(
+                            new Translation3d(
+                                poseDirection
+                                    .transformBy(
+                                        new Transform2d(adjustX, -adjustY, new Rotation2d()))
+                                    .getX(),
+                                poseDirection
+                                    .transformBy(
+                                        new Transform2d(adjustX, -adjustY, new Rotation2d()))
+                                    .getY(),
+                                level.height),
+                            new Rotation3d(
+                                0,
+                                Units.degreesToRadians(level.pitch),
+                                poseDirection.getRotation().getRadians())));
+                }
+                branchPositions.add(fillRight);
+                branchPositions.add(fillLeft);
+            }
+
+
+        }
+    }
+
+    public static class StagingPositions {
+        // Measured from the center of the ice cream
+        public static final Pose2d leftIceCream =
+            new Pose2d(Units.inchesToMeters(48), Units.inchesToMeters(230.5), new Rotation2d());
+        public static final Pose2d middleIceCream =
+            new Pose2d(Units.inchesToMeters(48), Units.inchesToMeters(158.5), new Rotation2d());
+        public static final Pose2d rightIceCream =
+            new Pose2d(Units.inchesToMeters(48), Units.inchesToMeters(86.5), new Rotation2d());
+    }
+
+    public enum ReefHeight {
+        L4(Units.inchesToMeters(72), -90),
+        L3(Units.inchesToMeters(47.625), -35),
+        L2(Units.inchesToMeters(31.875), -35),
+        L1(Units.inchesToMeters(18), 0);
+
+        ReefHeight(double height, double pitch)
+        {
+            this.height = height;
+            this.pitch = pitch; // in degrees
+        }
+
+        public final double height;
+        public final double pitch;
+    }
+
+    public static Pose2d getNearestReefFace(Pose2d currentPose)
+    {
+        return currentPose.nearest(List.of(FieldConstants.Reef.centerFaces));
+    }
+
+    public enum ReefSide {
+        LEFT,
+        RIGHT
+    }
+
+    public static Pose2d getNearestReefBranch(Pose2d currentPose, ReefSide side)
+    {
+        return FieldConstants.Reef.branchPositions
+            .get(List.of(FieldConstants.Reef.centerFaces).indexOf(getNearestReefFace(currentPose))
+                * 2 + (side == ReefSide.LEFT ? 1 : 0))
+            .get(FieldConstants.ReefHeight.L1).toPose2d();
+    }
+
+    public static Pose2d getNearestCoralStation(Pose2d currentPose)
+    {
+        if (currentPose.getTranslation().getX() > FieldConstants.fieldLength / 2) {
+            if (currentPose.getTranslation().getY() > FieldConstants.fieldWidth / 2) {
+                return FieldConstants.CoralStation.rightCenterFace
+                    .rotateAround(FieldConstants.fieldCenter, Rotation2d.k180deg);
+            } else {
+                return FieldConstants.CoralStation.leftCenterFace
+                    .rotateAround(FieldConstants.fieldCenter, Rotation2d.k180deg);
+            }
+        } else {
+            if (currentPose.getTranslation().getY() > FieldConstants.fieldWidth / 2) {
+                return FieldConstants.CoralStation.leftCenterFace;
+            } else {
+                return FieldConstants.CoralStation.rightCenterFace;
+            }
+        }
+    }
+}

--- a/2025-Robot-Code/src/main/java/frc/robot/RobotContainer.java
+++ b/2025-Robot-Code/src/main/java/frc/robot/RobotContainer.java
@@ -6,7 +6,6 @@ package frc.robot;
 
 import frc.robot.Constants.AlgaeConstants;
 import frc.robot.Constants.ElevatorConstants;
-import frc.robot.Constants.FieldConstants;
 import frc.robot.Constants.OperatorConstants;
 import frc.robot.FieldConstants.ReefSide;
 import frc.robot.commands.DriveCommands;
@@ -18,7 +17,6 @@ import frc.robot.util.AllianceFlipUtil;
 import static edu.wpi.first.units.Units.*;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.function.Supplier;
 
 import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
@@ -176,7 +174,7 @@ public class RobotContainer {
                 driverController.povRight().whileTrue(drivetrain.applyRequest(() -> point
                                 .withModuleDirection(new Rotation2d(-driverController.getLeftY(),
                                                 -driverController.getLeftX()))));
-                                                
+
                 driverController.a().whileTrue(elevator.setElevatorTarget(ElevatorConstants.kL1Height))
                                 .onFalse(elevator.setElevatorTarget(ElevatorConstants.kStowedHeight));
                 driverController.x().whileTrue(elevator.setElevatorTarget(ElevatorConstants.kL2Height))

--- a/2025-Robot-Code/src/main/java/frc/robot/RobotContainer.java
+++ b/2025-Robot-Code/src/main/java/frc/robot/RobotContainer.java
@@ -107,16 +107,12 @@ public class RobotContainer {
         }
 
         public void periodic() {
-                ArrayList<VisionHelper> cam1Results = vision.getCurrentPositionCam1();
-                ArrayList<VisionHelper> cam2Results = vision.getCurrentPositionCam2();
+                ArrayList<VisionHelper> cameraResults = vision.getVisionUpdates();
 
-                for (int i = 0; i < cam1Results.size(); i++) {
-                        VisionHelper cam1Result = cam1Results.get(i);
-                        drivetrain.addVisionMeasurement(cam1Result.getPose(), cam1Result.getTime());
-                }
-                for (int i = 0; i < cam2Results.size(); i++) {
-                        VisionHelper cam2Result = cam2Results.get(i);
-                        drivetrain.addVisionMeasurement(cam2Result.getPose(), cam2Result.getTime());
+                for(VisionHelper result: cameraResults){
+                        
+                        double stdDevFactor = Math.pow(result.averageTagDistance, 2);
+                        drivetrain.addVisionMeasurement(result.getPose(), result.getTime());
                 }
 
                 Pose2d currentPose = drivetrain.getState().Pose;

--- a/2025-Robot-Code/src/main/java/frc/robot/RobotContainer.java
+++ b/2025-Robot-Code/src/main/java/frc/robot/RobotContainer.java
@@ -107,28 +107,49 @@ public class RobotContainer {
         }
 
         public void periodic() {
+<<<<<<< Updated upstream
                 ArrayList<VisionHelper> cameraResults = vision.getVisionUpdates();
 
                 for(VisionHelper result: cameraResults){
                         
                         double stdDevFactor = Math.pow(result.averageTagDistance, 2);
                         drivetrain.addVisionMeasurement(result.getPose(), result.getTime());
+=======
+                for (var pose : vision.getVisionResults()) {
+                        drivetrain.addVisionMeasurement(pose.getPose(), pose.getTime(),
+                                        pose.getVisionMeasurementStdDevs());
+>>>>>>> Stashed changes
                 }
 
                 Pose2d currentPose = drivetrain.getState().Pose;
                 AllianceFlipUtil.apply(currentPose);
 
+<<<<<<< Updated upstream
+=======
+                int face;
+                if (AllianceFlipUtil.shouldFlip()) {
+                        Pose2d closestFace = currentPose.nearest(Arrays.asList(FieldConstants.redCenterFaces));
+                        face = Arrays.asList(FieldConstants.redCenterFaces).indexOf(closestFace);
+                } else {
+                        Pose2d closestFace = currentPose.nearest(Arrays.asList(FieldConstants.blueCenterFaces));
+                        face = Arrays.asList(FieldConstants.blueCenterFaces).indexOf(closestFace);
+                }
+
+                field.setRobotPose((AllianceFlipUtil.shouldFlip()
+                                ? FieldConstants.redCenterFaces
+                                : FieldConstants.blueCenterFaces)[face]);
+
+>>>>>>> Stashed changes
                 var xDiff = drivetrain.getState().Pose.getX() - 7.1;
                 var yDiff = drivetrain.getState().Pose.getY() - 1.9;
 
-                SmartDashboard.putString("Aligned X", xDiff < -0.01 ? "Out (to cages)" : (xDiff > 0.01 ? "Closer (away from cages)" : "Aligned"));
+                SmartDashboard.putString("Aligned X", xDiff < -0.01 ? "Out (to cages)"
+                                : (xDiff > 0.01 ? "Closer (away from cages)" : "Aligned"));
                 SmartDashboard.putString("Aligned Y", yDiff < -0.01 ? "Left" : (yDiff > 0.01 ? "Right" : "Aligned"));
-                SmartDashboard.putBoolean("Aligned X (num)", 
-                        Math.abs(drivetrain.getState().Pose.getX() - 7.1) < 0.02
-                );
-                SmartDashboard.putBoolean("Aligned Y (num)", 
-                        Math.abs(drivetrain.getState().Pose.getY() - 1.9) < 0.02
-                );
+                SmartDashboard.putBoolean("Aligned X (num)",
+                                Math.abs(drivetrain.getState().Pose.getX() - 7.1) < 0.02);
+                SmartDashboard.putBoolean("Aligned Y (num)",
+                                Math.abs(drivetrain.getState().Pose.getY() - 1.9) < 0.02);
         }
 
         private void configureBindings() {

--- a/2025-Robot-Code/src/main/java/frc/robot/VisionHelper.java
+++ b/2025-Robot-Code/src/main/java/frc/robot/VisionHelper.java
@@ -1,7 +1,5 @@
 package frc.robot;
 
-import java.util.Optional;
-
 import edu.wpi.first.math.geometry.Pose2d;
 
 public class VisionHelper {

--- a/2025-Robot-Code/src/main/java/frc/robot/VisionHelper.java
+++ b/2025-Robot-Code/src/main/java/frc/robot/VisionHelper.java
@@ -1,21 +1,33 @@
 package frc.robot;
 
+<<<<<<< Updated upstream
+=======
+import edu.wpi.first.math.Matrix;
+>>>>>>> Stashed changes
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
 
 public class VisionHelper {
-    public Pose2d pose;
-    public double time;
+    private Pose2d pose;
+    private double time;
+    private Matrix<N3, N1> visionMeasurementStdDevs;
 
-    public VisionHelper(Pose2d pose, double time){
+    public VisionHelper(Pose2d pose, double time, Matrix<N3, N1> visionMeasurementStdDevs) {
         this.pose = pose;
         this.time = time;
+        this.visionMeasurementStdDevs = visionMeasurementStdDevs;
     }
 
-    public Pose2d getPose(){
+    public Pose2d getPose() {
         return pose;
     }
 
-    public double getTime(){
+    public double getTime() {
         return time;
+    }
+
+    public Matrix<N3, N1> getVisionMeasurementStdDevs() {
+        return visionMeasurementStdDevs;
     }
 }

--- a/2025-Robot-Code/src/main/java/frc/robot/commands/DriveCommands.java
+++ b/2025-Robot-Code/src/main/java/frc/robot/commands/DriveCommands.java
@@ -1,0 +1,122 @@
+package frc.robot.commands;
+
+import static edu.wpi.first.units.Units.MetersPerSecond;
+
+import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
+
+import com.ctre.phoenix6.swerve.SwerveRequest;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.controller.ProfiledPIDController;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.math.trajectory.TrapezoidProfile;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.generated.TunerConstants;
+import frc.robot.subsystems.CommandSwerveDrivetrain;
+
+public class DriveCommands {
+    
+    private static final double DEADBAND = 0.1;
+    private static final double ANGLE_KP = 5.0;
+    private static final double ANGLE_KD = 0.4;
+    private static final double ANGLE_MAX_VELOCITY = 8.0;
+    private static final double ANGLE_MAX_ACCELERATION = 20.0;
+
+    public static final double DRIVE_BASE_RADIUS = Math.max(
+        Math.max(
+            Math.hypot(TunerConstants.FrontLeft.LocationX, TunerConstants.FrontLeft.LocationY),
+            Math.hypot(TunerConstants.FrontRight.LocationX, TunerConstants.FrontRight.LocationY)
+        ),
+        Math.max(
+            Math.hypot(TunerConstants.BackLeft.LocationX, TunerConstants.BackLeft.LocationY),
+            Math.hypot(TunerConstants.BackRight.LocationX, TunerConstants.BackRight.LocationY)
+        )
+    );
+
+    private static double getMaxLinearSpeedMetersPerSecond() {
+        return TunerConstants.kSpeedAt12Volts.in(MetersPerSecond);
+    }
+
+    /**
+     * Gets a linear velocity as input from the driver joystick, treating the X and Y component as legs of a right triangle,
+     * and calculates the hypotenuse 
+     * @param x - the X component of the magnitude
+     * @param y - the Y component of the magnitude
+     * @return
+     * 
+     */
+    private static Translation2d getLinearVelocityFromJoystick(double x, double y) {
+        // Apply a deadband to the joystick inputs
+        double magnitude = MathUtil.applyDeadband(Math.hypot(x, y), DEADBAND);
+        Rotation2d linearDirection = new Rotation2d(Math.atan2(x, y));
+
+        // Squared inputs
+        magnitude = magnitude * magnitude;
+
+        return new Pose2d(new Translation2d(), linearDirection).transformBy(new Transform2d(magnitude, 0.0, new Rotation2d())).getTranslation();
+    }
+    
+    /***
+     * Robot relative drive command that uses the joystick for linear control towards a pose.
+     * This uses a PID for aligning with the target laterally, and PID for angular control. Used for approaching
+     * a known pose, from a short distance away. The approachSupplier must supply a Pose2d with a rotation facing AWAY from
+     * the target.
+     * @param drive
+     * @param ySupplier
+     * @param approachSupplier
+     * @return
+     */
+    public static Command joystickApproach(CommandSwerveDrivetrain drive, DoubleSupplier ySupplier, Supplier<Pose2d> approachSupplier) {
+        ProfiledPIDController angleController = new ProfiledPIDController(ANGLE_KP, 0.0, ANGLE_KD, new TrapezoidProfile.Constraints(ANGLE_MAX_VELOCITY, ANGLE_MAX_ACCELERATION));
+        angleController.enableContinuousInput(-Math.PI, Math.PI);
+        ProfiledPIDController alignController = new ProfiledPIDController(1.0, 0.0, 0.0, new TrapezoidProfile.Constraints(ANGLE_MAX_VELOCITY, ANGLE_MAX_ACCELERATION));
+        alignController.setGoal(0);
+
+        return Commands.run(
+        () -> { // Command
+            Translation2d currentTranslation = drive.getState().Pose.getTranslation();
+            Translation2d approachTranslation = approachSupplier.get().getTranslation();
+            double distanceToApproach = currentTranslation.getDistance(approachTranslation);
+            
+            Rotation2d alignmentDirection = approachSupplier.get().getRotation();
+
+            // Find lateral distance to Goal Pose
+            Translation2d goalTranslation = new Translation2d(
+                alignmentDirection.getCos() * distanceToApproach + approachTranslation.getX(),
+                alignmentDirection.getSin() * distanceToApproach + approachTranslation.getY()
+            );
+
+            Translation2d robotToGoal = currentTranslation.minus(goalTranslation);
+            double distanceToGoal = Math.hypot(robotToGoal.getX(), robotToGoal.getY());
+
+            // Calculate lateral linear velocity
+            Translation2d offsetVector = new Translation2d(alignController.calculate(distanceToGoal), 0).rotateBy(robotToGoal.getAngle());
+
+            // Calculate total linear velocity
+            Translation2d linearVelocity = getLinearVelocityFromJoystick(
+                0, 
+                ySupplier.getAsDouble()
+            ).rotateBy(approachSupplier.get().getRotation()).rotateBy(Rotation2d.kCCW_90deg).plus(offsetVector);
+
+            double theta = angleController.calculate(drive.getState().Pose.getRotation().getRadians(), approachSupplier.get().getRotation().rotateBy(Rotation2d.k180deg).getRadians());
+
+            ChassisSpeeds speeds = new ChassisSpeeds(
+                linearVelocity.getX() * getMaxLinearSpeedMetersPerSecond(), 
+                linearVelocity.getY() * getMaxLinearSpeedMetersPerSecond(),
+                theta
+            );
+            // Create a robot-centric swerve request to drive to the approach target, using the calculated chassis speeds.
+            SwerveRequest.ApplyRobotSpeeds request = new SwerveRequest.ApplyRobotSpeeds();
+            drive.applyRequest(() -> request
+                .withSpeeds(ChassisSpeeds.fromFieldRelativeSpeeds(speeds, drive.getState().Pose.getRotation())));
+        },
+        drive // Requirements
+        ).beforeStarting(() -> angleController.reset(drive.getState().Pose.getRotation().getRadians()));
+    }
+}

--- a/2025-Robot-Code/src/main/java/frc/robot/commands/DriveCommands.java
+++ b/2025-Robot-Code/src/main/java/frc/robot/commands/DriveCommands.java
@@ -104,17 +104,16 @@ public class DriveCommands {
                 ySupplier.getAsDouble()
             ).rotateBy(approachSupplier.get().getRotation()).rotateBy(Rotation2d.kCCW_90deg).plus(offsetVector);
 
-            double theta = angleController.calculate(drive.getState().Pose.getRotation().getRadians(), approachSupplier.get().getRotation().rotateBy(Rotation2d.k180deg).getRadians());
+            double omega = angleController.calculate(drive.getState().Pose.getRotation().getRadians(), approachSupplier.get().getRotation().rotateBy(Rotation2d.k180deg).getRadians());
 
             ChassisSpeeds speeds = new ChassisSpeeds(
                 linearVelocity.getX() * getMaxLinearSpeedMetersPerSecond(), 
                 linearVelocity.getY() * getMaxLinearSpeedMetersPerSecond(),
-                theta
+                omega
             );
             // Create a robot-centric swerve request to drive to the approach target, using the calculated chassis speeds.
-            SwerveRequest.ApplyRobotSpeeds request = new SwerveRequest.ApplyRobotSpeeds();
-            drive.applyRequest(() -> request
-                .withSpeeds(ChassisSpeeds.fromFieldRelativeSpeeds(speeds, drive.getState().Pose.getRotation())));
+            SwerveRequest.ApplyFieldSpeeds request = new SwerveRequest.ApplyFieldSpeeds();
+            drive.applyRequest(() -> request.withSpeeds(speeds));
         },
         drive // Requirements
         ).beforeStarting(() -> angleController.reset(drive.getState().Pose.getRotation().getRadians()));

--- a/2025-Robot-Code/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/2025-Robot-Code/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -43,7 +43,7 @@ import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.util.AllianceFlipUtil;
 import frc.robot.Constants.AutoConstants;
 import frc.robot.Constants.DriveConstants;
-import frc.robot.Constants.FieldConstants;
+import frc.robot.FieldConstants;
 import frc.robot.generated.TunerConstants.TunerSwerveDrivetrain;
 
 
@@ -345,53 +345,5 @@ private void ConfigureAutoBuilder(){
         Matrix<N3, N1> visionMeasurementStdDevs
     ) {
         super.addVisionMeasurement(visionRobotPoseMeters, Utils.fpgaToCurrentTime(timestampSeconds), visionMeasurementStdDevs);
-    }
-
-    /***
-     * Based on the vehicles current location, return a scoring pose.
-     * @param isRight True if the right pole is selected.
-     * @return Pose2d of the scoring location.
-     */
-    public Pose2d getScoringPose(boolean isRight){
-        Pose2d currentPose = getState().Pose;
-        AllianceFlipUtil.apply(currentPose);
-
-        int face;
-        if (AllianceFlipUtil.shouldFlip()) {
-            var closestFace = currentPose.nearest(Arrays.asList(FieldConstants.redCenterFaces));
-            face = Arrays.asList(FieldConstants.redCenterFaces).indexOf(closestFace);
-        } else {
-            var closestFace = currentPose.nearest(Arrays.asList(FieldConstants.blueCenterFaces));
-            face = Arrays.asList(FieldConstants.blueCenterFaces).indexOf(closestFace);
-        }
-        return AllianceFlipUtil.apply(FieldConstants.kScoringPoses.get(face).get(isRight));
-    }
-
-    /***
-     * Given a destination pose, use PID to move the robot to that pose.
-     * This is optimized for short distances and small rotations,
-     * and relies on the operator getting most of the way there.
-     * @param destinationPoseOptional The destination pose to move to
-     * @return Command which exits when it is near the desired pose
-     */
-    public Command moveToScorePose(boolean isRight) {
-        return defer(() -> {
-            var pose = getScoringPose(isRight);
-            SmartDashboard.putString("target pose", "X: " + pose.getX() + 
-                        ", Y: " + pose.getY() + ", Heading: " +
-                        pose.getRotation());
-            System.out.println("----- PATHFINDING TO POSE -----\n\t" + pose.toString());
-            PathConstraints constraints = new PathConstraints(
-                3.0, 
-                4.0, 
-                Units.degreesToRadians(540), 
-                Units.degreesToRadians(720)
-            );
-            return AutoBuilder.pathfindToPose(
-                pose,
-                constraints, 
-                0.0
-            );
-        });
     }
 }

--- a/2025-Robot-Code/src/main/java/frc/robot/subsystems/Vision.java
+++ b/2025-Robot-Code/src/main/java/frc/robot/subsystems/Vision.java
@@ -2,26 +2,39 @@ package frc.robot.subsystems;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.photonvision.PhotonCamera;
 
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.Constants.VisionConstants;
 import frc.robot.VisionHelper;
+import frc.robot.Constants.VisionConstants;
 
-public class Vision extends SubsystemBase{
+public class Vision extends SubsystemBase {
     static AprilTagFieldLayout mFieldLayout;
     static boolean useCustomField = false;
-    static{
+    static double linearStdDevBaseline = 0.02;
+    static double angularStdDevBaseline = 0.06;
+
+    public static record PoseObservation(
+            double timestamp, Pose3d pose, double ambiguity, int tagCount, double averageTagDistance) {
+    }
+
+    static {
         try {
-            mFieldLayout = new AprilTagFieldLayout(Path.of(Filesystem.getDeployDirectory().getAbsolutePath() + "/weldedlayout.json"));
+            mFieldLayout = new AprilTagFieldLayout(
+                    Path.of(Filesystem.getDeployDirectory().getAbsolutePath() + "/weldedlayout.json"));
             useCustomField = true;
         } catch (Exception e) {
             // TODO: handle exception
@@ -32,131 +45,90 @@ public class Vision extends SubsystemBase{
     final PhotonCamera mCamera1 = new PhotonCamera(VisionConstants.kCamera1Name);
     final PhotonCamera mCamera2 = new PhotonCamera(VisionConstants.kCamera2Name);
 
-
-    public ArrayList<VisionHelper> getVisionUpdates() {
-        ArrayList<VisionHelper> poses = new ArrayList<>();
-
-        var results = mCamera1.getAllUnreadResults();
-
-        for (var result : results) {
-            var multitag = result.multitagResult;
-            Transform3d fieldToCamera = null;
-
-            if (multitag.isPresent()) {
-                fieldToCamera = multitag.get().estimatedPose.best;
-            } else if (result.targets.isEmpty()) 
-                continue;
-            else {
-                var target = result.targets.get(0);
-                var tagPoseOptional = mFieldLayout.getTagPose(target.fiducialId);
-                if (tagPoseOptional.isEmpty())
-                    continue;
-                
-                Pose3d tagPose = tagPoseOptional.get();
-                Transform3d fieldToTarget = new Transform3d(tagPose.getTranslation(), tagPose.getRotation());
-                Transform3d cameraToTarget = target.bestCameraToTarget;
-                fieldToCamera = fieldToTarget.plus(cameraToTarget.inverse());
-            }
-
-            Transform3d fieldToRobot = fieldToCamera.plus(VisionConstants.kRobotToCam1.inverse());
-            Pose3d robotPose = new Pose3d(fieldToRobot.getTranslation(), fieldToRobot.getRotation());
-            poses.add(new VisionHelper(robotPose.toPose2d(), result.getTimestampSeconds()));
+    public ArrayList<VisionHelper> getVisionResults() {
+        ArrayList<VisionHelper> outputs = new ArrayList<>();
+        for (var observation : getObservations(mCamera1, VisionConstants.kRobotToCam1)) {
+            double stdDevFactor = Math.pow(observation.averageTagDistance(), 2.0) / observation.tagCount();
+            double linearStdDev = linearStdDevBaseline * stdDevFactor;
+            double angularStdDev = angularStdDevBaseline * stdDevFactor;
+            outputs.add(new VisionHelper(
+                    observation.pose.toPose2d(), observation.timestamp(),
+                    VecBuilder.fill(linearStdDev, linearStdDev, angularStdDev)));
         }
-
-        results = mCamera2.getAllUnreadResults();
-
-        for (var result : results) {
-            var multitag = result.multitagResult;
-            Transform3d fieldToCamera = null;
-
-            if (multitag.isPresent()) {
-                fieldToCamera = multitag.get().estimatedPose.best;
-            } else if (result.targets.isEmpty()) 
-                continue;
-            else {
-                var target = result.targets.get(0);
-                var tagPoseOptional = mFieldLayout.getTagPose(target.fiducialId);
-                if (tagPoseOptional.isEmpty())
-                    continue;
-                
-                Pose3d tagPose = tagPoseOptional.get();
-                Transform3d fieldToTarget = new Transform3d(tagPose.getTranslation(), tagPose.getRotation());
-                Transform3d cameraToTarget = target.bestCameraToTarget;
-                fieldToCamera = fieldToTarget.plus(cameraToTarget.inverse());
-            }
-
-            Transform3d fieldToRobot = fieldToCamera.plus(VisionConstants.kRobotToCam2.inverse());
-            Pose3d robotPose = new Pose3d(fieldToRobot.getTranslation(), fieldToRobot.getRotation());
-            poses.add(new VisionHelper(robotPose.toPose2d(), result.getTimestampSeconds()));
+        for (var observation : getObservations(mCamera2, VisionConstants.kRobotToCam2)) {
+            double stdDevFactor = Math.pow(observation.averageTagDistance(), 2.0) / observation.tagCount();
+            double linearStdDev = linearStdDevBaseline * stdDevFactor;
+            double angularStdDev = angularStdDevBaseline * stdDevFactor;
+            outputs.add(new VisionHelper(
+                    observation.pose.toPose2d(), observation.timestamp(),
+                    VecBuilder.fill(linearStdDev, linearStdDev, angularStdDev)));
         }
-
-        return poses;
+        return outputs;
     }
 
-    public ArrayList<VisionHelper> getCurrentPositionCam1(){
-        var results = mCamera1.getAllUnreadResults();
-        ArrayList<VisionHelper> returnPoses = new ArrayList<VisionHelper>();
+    public List<PoseObservation> getObservations(PhotonCamera camera, Transform3d robotToCamera) {
+        // Read new camera observations
+        Set<Short> tagIds = new HashSet<>();
+        List<PoseObservation> poseObservations = new LinkedList<>();
+        for (var result : camera.getAllUnreadResults()) {
+            // Add pose observation
+            if (result.multitagResult.isPresent()) { // Multitag result
+                var multitagResult = result.multitagResult.get();
 
-        for(int i = 0; i < results.size(); i++){
-            if (results.get(i).multitagResult.isPresent()) {
-                Transform3d fieldToCamera = results.get(i).multitagResult.get().estimatedPose.best;
-                Transform3d fieldToRobot = fieldToCamera.plus(VisionConstants.kRobotToCam1.inverse());
-                returnPoses.add(new VisionHelper(
-                    (new Pose3d(fieldToRobot.getTranslation(), fieldToRobot.getRotation()).toPose2d()),
-                    results.get(i).getTimestampSeconds()
-                ));
-            } else if (!results.get(i).targets.isEmpty()){
-                var target = results.get(i).targets.get(0);
-                
+                // Calculate robot pose
+                Transform3d fieldToCamera = multitagResult.estimatedPose.best;
+                Transform3d fieldToRobot = fieldToCamera.plus(robotToCamera.inverse());
+                Pose3d robotPose = new Pose3d(fieldToRobot.getTranslation(), fieldToRobot.getRotation());
+
+                // Calculate average tag distance
+                double totalTagDistance = 0.0;
+                for (var target : result.targets) {
+                    totalTagDistance += target.bestCameraToTarget.getTranslation().getNorm();
+                }
+
+                // Add tag IDs
+                tagIds.addAll(multitagResult.fiducialIDsUsed);
+
+                // Add observation
+                poseObservations.add(
+                        new PoseObservation(
+                                result.getTimestampSeconds(), // Timestamp
+                                robotPose, // 3D pose estimate
+                                multitagResult.estimatedPose.ambiguity, // Ambiguity
+                                multitagResult.fiducialIDsUsed.size(), // Tag count
+                                totalTagDistance / result.targets.size() // Average tag distance
+                        ));
+
+            } else if (!result.targets.isEmpty()) { // Single tag result
+                var target = result.targets.get(0);
+
                 // Calculate robot pose
                 var tagPose = mFieldLayout.getTagPose(target.fiducialId);
                 if (tagPose.isPresent()) {
-                    Transform3d fieldToTarget =
-                        new Transform3d(tagPose.get().getTranslation(), tagPose.get().getRotation());
+                    Transform3d fieldToTarget = new Transform3d(tagPose.get().getTranslation(),
+                            tagPose.get().getRotation());
                     Transform3d cameraToTarget = target.bestCameraToTarget;
                     Transform3d fieldToCamera = fieldToTarget.plus(cameraToTarget.inverse());
-                    Transform3d fieldToRobot = fieldToCamera.plus(VisionConstants.kRobotToCam1.inverse());
-                    returnPoses.add(new VisionHelper(
-                        new Pose3d(fieldToRobot.getTranslation(), fieldToRobot.getRotation()).toPose2d(),
-                        results.get(i).getTimestampSeconds()
-                    ));
+                    Transform3d fieldToRobot = fieldToCamera.plus(robotToCamera.inverse());
+                    Pose3d robotPose = new Pose3d(fieldToRobot.getTranslation(), fieldToRobot.getRotation());
+
+                    // Add tag ID
+                    tagIds.add((short) target.fiducialId);
+
+                    // Add observation
+                    poseObservations.add(
+                            new PoseObservation(
+                                    result.getTimestampSeconds(), // Timestamp
+                                    robotPose, // 3D pose estimate
+                                    target.poseAmbiguity, // Ambiguity
+                                    1, // Tag count
+                                    cameraToTarget.getTranslation().getNorm() // Average tag distance
+                            ));
                 }
             }
         }
-        return returnPoses;
-    }
 
-    public ArrayList<VisionHelper> getCurrentPositionCam2(){
-        var results = mCamera2.getAllUnreadResults();
-        ArrayList<VisionHelper> returnPoses = new ArrayList<VisionHelper>();
-        for(int i = 0; i < results.size(); i++){
-            if (results.get(i).multitagResult.isPresent()) {
-                Transform3d fieldToCamera = results.get(i).multitagResult.get().estimatedPose.best;
-                Transform3d fieldToRobot = fieldToCamera.plus(VisionConstants.kRobotToCam2.inverse());
-                returnPoses.add(new VisionHelper(
-                    new Pose3d(fieldToRobot.getTranslation(), fieldToRobot.getRotation()).toPose2d(),
-                    results.get(i).getTimestampSeconds()
-                ));
-            }
-            else if(!results.get(i).targets.isEmpty()){
-                var target = results.get(i).targets.get(0);
-                
-                // Calculate robot pose
-                var tagPose = mFieldLayout.getTagPose(target.fiducialId);
-                if (tagPose.isPresent()) {
-                    Transform3d fieldToTarget =
-                        new Transform3d(tagPose.get().getTranslation(), tagPose.get().getRotation());
-                    Transform3d cameraToTarget = target.bestCameraToTarget;
-                    Transform3d fieldToCamera = fieldToTarget.plus(cameraToTarget.inverse());
-                    Transform3d fieldToRobot = fieldToCamera.plus(VisionConstants.kRobotToCam2.inverse());
-                    returnPoses.add( new VisionHelper(
-                        new Pose3d(fieldToRobot.getTranslation(), fieldToRobot.getRotation()).toPose2d(),
-                        results.get(i).getTimestampSeconds()
-                    ));
-                }
-            }
-        }
-        return returnPoses;
+        // Save pose observations to inputs object
+        return poseObservations;
     }
-
 }

--- a/2025-Robot-Code/src/main/java/frc/robot/util/AllianceFlipUtil.java
+++ b/2025-Robot-Code/src/main/java/frc/robot/util/AllianceFlipUtil.java
@@ -5,17 +5,17 @@ package frc.robot.util;
 
 import edu.wpi.first.math.geometry.*;
 import edu.wpi.first.wpilibj.DriverStation;
-import frc.robot.Constants.FieldConstants;
+import frc.robot.FieldConstants;
 
 
 public class AllianceFlipUtil {
 
   public static double applyX(double x) {
-    return shouldFlip() ? FieldConstants.kFieldLength - x : x;
+    return shouldFlip() ? FieldConstants.fieldLength - x : x;
   }
 
   public static double applyY(double y) {
-    return shouldFlip() ? FieldConstants.kFieldWidth - y : y;
+    return shouldFlip() ? FieldConstants.fieldWidth - y : y;
   }
 
   public static Translation2d apply(Translation2d translation) {
@@ -33,10 +33,10 @@ public class AllianceFlipUtil {
   }
 
   public static double applyXUnchecked(double x) {
-    return FieldConstants.kFieldLength - x;
+    return FieldConstants.fieldLength - x;
   }
   public static double applyYUnchecked(double y) {
-    return FieldConstants.kFieldWidth - y;
+    return FieldConstants.fieldWidth - y;
   }
   public static Translation2d applyUnchecked(Translation2d translation) {
     return new Translation2d(applyXUnchecked(translation.getX()), applyYUnchecked(translation.getY()));


### PR DESCRIPTION
This pull request modifies the AutoAlignment features to use JoystickApproach as opposed to using PathFinder or PathPlaner.

JoystickApproach is a command which when given a pose2d, will approach the given pose by using a PID controller to align laterally and angularly, and will allow the driver to use the joysticks Y component to travel closer to the pose (robot relative, not field relative). This means that the driver controls the speed at which they approach the pose, but the alignment of the robot and heading are locked to the target pose.

Additionally, this PR changes FieldConstants to use the FieldConstants file given by MechanicalAdvantage, which does not hardcode reef poses and instead fills them from a first given face by rotating them around the field origin and center of the reef.